### PR TITLE
Initial support for Haiku

### DIFF
--- a/ascii/distro/haiku
+++ b/ascii/distro/haiku
@@ -1,0 +1,19 @@
+"\
+${c2}          :dc'
+       'l:;'${c1},${c2}'ck.    .;dc:.
+       co    ${c1}..${c2}k.  .;;   ':o.
+       co    ${c1}..${c2}k. ol      ${c1}.${c2}0.
+       co    ${c1}..${c2}k. oc     ${c1}..${c2}0.
+       co    ${c1}..${c2}k. oc     ${c1}..${c2}0.
+.Ol,.  co ${c1}...''${c2}Oc;kkodxOdddOoc,.
+ ';lxxlxOdxkxk0kd${c1}oooll${c2}dl${c1}ccc:${c2}clxd;
+     ..${c1}oOolllllccccccc:::::${c2}od;
+       cx:ooc${c1}:::::::;${c2}cooolcX.
+       cd${c1}.${c2}''cloxdoollc' ${c1}...${c2}0.
+       cd${c1}......${c2}k;${c1}.${c2}xl${c1}....  .${c2}0.
+       .::c${c1};..${c2}cx;${c1}.${c2}xo${c1}..... .${c2}0.
+          '::c'${c1}...${c2}do${c1}..... .${c2}K,
+                  cd,.${c1}....:${c2}O,${c1}
+                    ':clod:'${c1}
+                        ${c1}
+"

--- a/neofetch
+++ b/neofetch
@@ -316,53 +316,54 @@ getuptime() {
             uptime="$(uptime -u)"
             uptime="${uptime/up }"
         ;;
-    *)
-        # Get uptime in seconds
-        case "$os" in
-            "Linux" | "Windows")
-                seconds="$(< /proc/uptime)"
-                seconds="${seconds/.*}"
-            ;;
 
-            "Mac OS X" | "iPhone OS" | "BSD")
-                boot="$(sysctl -n kern.boottime)"
-                boot="${boot/'{ sec = '}"
-                boot="${boot/,*}"
+        *)
+            # Get uptime in seconds
+            case "$os" in
+                "Linux" | "Windows")
+                    seconds="$(< /proc/uptime)"
+                    seconds="${seconds/.*}"
+                ;;
 
-                # Get current date in seconds
-                now="$(date +%s)"
-                seconds="$((now - boot))"
-            ;;
+                "Mac OS X" | "iPhone OS" | "BSD")
+                    boot="$(sysctl -n kern.boottime)"
+                    boot="${boot/'{ sec = '}"
+                    boot="${boot/,*}"
 
-            "Solaris")
-                seconds="$(kstat -p unix:0:system_misc:snaptime | awk '{print $2}')"
-                seconds="${seconds/.*}"
-            ;;
-        esac
+                    # Get current date in seconds
+                    now="$(date +%s)"
+                    seconds="$((now - boot))"
+                ;;
 
-        days="$((seconds / 60 / 60 / 24)) days"
-        hours="$((seconds / 60 / 60 % 24)) hours"
-        minutes="$((seconds / 60 % 60)) minutes"
+                "Solaris")
+                    seconds="$(kstat -p unix:0:system_misc:snaptime | awk '{print $2}')"
+                    seconds="${seconds/.*}"
+                ;;
+            esac
 
-        case "$days" in
-            "0 days") unset days ;;
-            "1 days") days="${days/s}" ;;
-        esac
+            days="$((seconds / 60 / 60 / 24)) days"
+            hours="$((seconds / 60 / 60 % 24)) hours"
+            minutes="$((seconds / 60 % 60)) minutes"
 
-        case "$hours" in
-            "0 hours") unset hours ;;
-            "1 hours") hours="${hours/s}" ;;
-        esac
+            case "$days" in
+                "0 days") unset days ;;
+                "1 days") days="${days/s}" ;;
+            esac
 
-        case "$minutes" in
-            "0 minutes") unset minutes ;;
-            "1 minutes") minutes="${minutes/s}" ;;
-        esac
+            case "$hours" in
+                "0 hours") unset hours ;;
+                "1 hours") hours="${hours/s}" ;;
+            esac
 
-        uptime="${days:+$days, }${hours:+$hours, }${minutes}"
-        uptime="${uptime%', '}"
-        uptime="${uptime:-${seconds} seconds}"
-    ;;
+            case "$minutes" in
+                "0 minutes") unset minutes ;;
+                "1 minutes") minutes="${minutes/s}" ;;
+            esac
+
+            uptime="${days:+$days, }${hours:+$hours, }${minutes}"
+            uptime="${uptime%', '}"
+            uptime="${uptime:-${seconds} seconds}"
+        ;;
     esac
 
     # Make the output of uptime smaller.
@@ -1735,6 +1736,12 @@ getbattery() {
             battery="${battery/EstimatedChargeRemaining'='}"
             [ "$battery" ] && \
                 battery+="%"
+        ;;
+
+        "Haiku")
+            battery0full="$(awk -F '[^0-9]*' 'NR==2 {print $4}' /dev/power/acpi_battery/0)"
+            battery0now="$(awk -F '[^0-9]*' 'NR==5 {print $4}' /dev/power/acpi_battery/0)"
+            battery="$((battery0full / battery0now * 100))%"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -1739,8 +1739,8 @@ getbattery() {
         ;;
 
         "Haiku")
-            battery0full="$(awk -F '[^0-9]*' 'NR==5 {print $4}' /dev/power/acpi_battery/0)"
-            battery0now="$(awk -F '[^0-9]*' 'NR==2 {print $4}' /dev/power/acpi_battery/0)"
+            battery0full="$(awk -F '[^0-9]*' 'NR==2 {print $4}' /dev/power/acpi_battery/0)"
+            battery0now="$(awk -F '[^0-9]*' 'NR==5 {print $4}' /dev/power/acpi_battery/0)"
             battery="$((battery0full / battery0now * 100))%"
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -1739,8 +1739,8 @@ getbattery() {
         ;;
 
         "Haiku")
-            battery0full="$(awk -F '[^0-9]*' 'NR==2 {print $4}' /dev/power/acpi_battery/0)"
-            battery0now="$(awk -F '[^0-9]*' 'NR==5 {print $4}' /dev/power/acpi_battery/0)"
+            battery0full="$(awk -F '[^0-9]*' 'NR==5 {print $4}' /dev/power/acpi_battery/0)"
+            battery0now="$(awk -F '[^0-9]*' 'NR==2 {print $4}' /dev/power/acpi_battery/0)"
             battery="$((battery0full / battery0now * 100))%"
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -30,6 +30,7 @@ getos() {
         *"BSD" | "DragonFly" | "Bitrig") os="BSD" ;;
         "CYGWIN"*) os="Windows" ;;
         "SunOS") os="Solaris" ;;
+        "Haiku") os="Haiku" ;;
         *) printf "%s\n" "Unknown OS detected: $(uname)"; exit 1 ;;
     esac
 }
@@ -253,6 +254,10 @@ getdistro() {
             esac
             distro="${distro/\(*}"
         ;;
+
+        "Haiku")
+            distro="$(uname -sv | awk '{print $1 " " $2}')"
+        ;;
     esac
 
     # Get architecture
@@ -303,51 +308,62 @@ getkernel() {
 # Uptime {{{
 
 getuptime() {
-    # Get uptime in seconds
+
+    # Since Haiku's uptime cannot be fetched in seconds, a case outside
+    # the usual case is needed
     case "$os" in
-        "Linux" | "Windows")
-            seconds="$(< /proc/uptime)"
-            seconds="${seconds/.*}"
+        "Haiku")
+            uptime="$(uptime -u)"
+            uptime="${uptime/up }"
         ;;
+    *)
+        # Get uptime in seconds
+        case "$os" in
+            "Linux" | "Windows")
+                seconds="$(< /proc/uptime)"
+                seconds="${seconds/.*}"
+            ;;
 
-        "Mac OS X" | "iPhone OS" | "BSD")
-            boot="$(sysctl -n kern.boottime)"
-            boot="${boot/'{ sec = '}"
-            boot="${boot/,*}"
+            "Mac OS X" | "iPhone OS" | "BSD")
+                boot="$(sysctl -n kern.boottime)"
+                boot="${boot/'{ sec = '}"
+                boot="${boot/,*}"
 
-            # Get current date in seconds
-            now="$(date +%s)"
-            seconds="$((now - boot))"
-        ;;
+                # Get current date in seconds
+                now="$(date +%s)"
+                seconds="$((now - boot))"
+            ;;
 
-        "Solaris")
-            seconds="$(kstat -p unix:0:system_misc:snaptime | awk '{print $2}')"
-            seconds="${seconds/.*}"
-        ;;
+            "Solaris")
+                seconds="$(kstat -p unix:0:system_misc:snaptime | awk '{print $2}')"
+                seconds="${seconds/.*}"
+            ;;
+        esac
+
+        days="$((seconds / 60 / 60 / 24)) days"
+        hours="$((seconds / 60 / 60 % 24)) hours"
+        minutes="$((seconds / 60 % 60)) minutes"
+
+        case "$days" in
+            "0 days") unset days ;;
+            "1 days") days="${days/s}" ;;
+        esac
+
+        case "$hours" in
+            "0 hours") unset hours ;;
+            "1 hours") hours="${hours/s}" ;;
+        esac
+
+        case "$minutes" in
+            "0 minutes") unset minutes ;;
+            "1 minutes") minutes="${minutes/s}" ;;
+        esac
+
+        uptime="${days:+$days, }${hours:+$hours, }${minutes}"
+        uptime="${uptime%', '}"
+        uptime="${uptime:-${seconds} seconds}"
+    ;;
     esac
-
-    days="$((seconds / 60 / 60 / 24)) days"
-    hours="$((seconds / 60 / 60 % 24)) hours"
-    minutes="$((seconds / 60 % 60)) minutes"
-
-    case "$days" in
-        "0 days") unset days ;;
-        "1 days") days="${days/s}" ;;
-    esac
-
-    case "$hours" in
-        "0 hours") unset hours ;;
-        "1 hours") hours="${hours/s}" ;;
-    esac
-
-    case "$minutes" in
-        "0 minutes") unset minutes ;;
-        "1 minutes") minutes="${minutes/s}" ;;
-    esac
-
-    uptime="${days:+$days, }${hours:+$hours, }${minutes}"
-    uptime="${uptime%', '}"
-    uptime="${uptime:-${seconds} seconds}"
 
     # Make the output of uptime smaller.
     case "$uptime_shorthand" in
@@ -460,6 +476,10 @@ getpackages() {
             # Count chocolatey packages
             [ -d "/cygdrive/c/ProgramData/chocolatey/lib" ] && \
                 packages="$((packages+=$(ls -1 /cygdrive/c/ProgramData/chocolatey/lib | wc -l)))"
+        ;;
+
+        "Haiku")
+            packages="$(ls -1 /boot/system/package-links | wc -l)"
         ;;
     esac
 
@@ -845,6 +865,24 @@ getcpu() {
 
             cpu="$cpu @ ${speed}GHz"
         ;;
+
+        "Haiku")
+            cpu="$(sysinfo -cpu | awk -F '\\"' '/CPU #0/ {print $2}')"
+            cpu="${cpu/@*}"
+            speed="$(sysinfo -cpu | awk '/running at/ {print $NF; exit}')"
+            speed="${speed/MHz}"
+            speed="$((speed / 100))"
+            cores="$(sysinfo -cpu | grep -c 'CPU #')"
+
+            # Fix for speed under 1ghz
+            if [ -z ] "${speed:1}"; then
+                speed="0.${speed}"
+            else
+                speed="${speed:0:1}.${speed:1}"
+            fi
+
+            cpu="$cpu @ ${speed}GHz"
+        ;;
     esac
 
     # Remove uneeded patterns from cpu output
@@ -1025,6 +1063,10 @@ getgpu() {
             gpu="$(wmic path Win32_VideoController get caption /value)"
             gpu="${gpu/Caption'='}"
         ;;
+
+        "Haiku")
+            gpu="$(listdev | grep -A2 -e 'device Display controller' | awk -F':' '/device beef/ {print $2}')"
+        ;;
     esac
 
     if [ "$gpu_brand" == "off" ]; then
@@ -1084,6 +1126,12 @@ getmemory() {
             memtotal="$(prtconf | grep Memory | head -1 | awk 'BEGIN {FS=" "} {print $3}')"
             memfree="$(($(sar -r 1 1 | tail -1 | awk 'BEGIN {FS=" "} {print $2}') / 1024))"
             memused="$((memtotal - memfree))"
+        ;;
+
+        "Haiku")
+            memtotal=$(($(sysinfo -mem | head -n1 | cut -d'/' -f3 | tr -d ' ' | tr -d ')') / 1024 / 1024))
+            memused="$(sysinfo -mem | awk -F '\\/|)' '{print $2; exit}')"
+            memused="$((${memused/max} / 1024 / 1024))"
         ;;
     esac
     memory="${memused}MB / ${memtotal}MB"
@@ -1267,6 +1315,14 @@ getresolution() {
 
             [ "$width" ] && \
                 resolution="${width}x${height}"
+        ;;
+
+        "Haiku")
+            resolution="$(screenmode | awk -F ' |, ' '{printf $2 "x" $3 " @ " $6 $7}')"
+
+            case "$refresh_rate" in
+                "off") resolution="${resolution/ @*}" ;;
+            esac
         ;;
     esac
 
@@ -1715,6 +1771,11 @@ getlocalip() {
         "Windows")
             localip="$(ipconfig | awk -F ': ' '/IPv4 Address/ {printf $2}')"
         ;;
+
+        "Haiku")
+            localip="$(ifconfig | awk -F ': ' '/Bcast/ {print $2}')"
+            localip="${localip/', Bcast'}"
+        ;;
     esac
 }
 
@@ -1793,6 +1854,11 @@ getbirthday() {
 
         "Solaris")
             birthday="$(ls -alct --full-time /var/sadm/system/logs/install_log | awk '{printf $6 " " $7}')"
+            date_cmd="$(date -d"$birthday" "$birthday_format")"
+        ;;
+
+        "Haiku")
+            birthday="$(ls -alctd --full-time /boot | awk '{printf $6 " " $7}')"
             date_cmd="$(date -d"$birthday" "$birthday_format")"
         ;;
     esac
@@ -2554,6 +2620,10 @@ colors() {
 
         "Windows"*)
             setcolors 1 2 4 3
+        ;;
+
+        "Haiku"*)
+            setcolors 2 0
         ;;
 
         "Raspbian"* | *)

--- a/neofetch
+++ b/neofetch
@@ -1619,7 +1619,7 @@ getdisk() {
             esac
         ;;
 
-        "Mac OS X" | "BSD")
+        "Mac OS X" | "BSD" | "Haiku")
             case "$distro" in
                 "FreeBSD"* | *"OS X"* | "Mac"* )
                     df_flags="-l -H /"


### PR DESCRIPTION
TODO:
- [x] OS
- [ ] getmodel
  - ~~may be possible with `listdev`~~, ~~but I need a testing device to back this up. I'll test on my laptop.~~ Nope, `listdev` didn't show anything.
- [x] getdistro
- [ ] getuptime
Since we changed `getuptime` behavior, we need another method for Haiku.
- [x] getpackages
- [x] getcpu
- [ ] getcpu_usage [1]
- [x] getgpu
- [x] getmemory
- [x] getresolution
- [ ] getde [2]
- [ ] getwm [2]
- [ ] getdisk [3]
- [ ] getbattery [4]
- [x] getlocalip
- [x] getbirthday
- [ ] getterm [1]

[1] This is Haiku's `ps`.
![virtualbox_haiku os_12_10_2016_17_16_50](https://cloud.githubusercontent.com/assets/15692230/19306465/02cb3bba-90a0-11e6-896e-1d0d37d785f0.png)

I have no idea what to do about it, and it doesn't even show anything about CPU, using `ps -i` shows memory info instead, unlike a sane and glorious `ps aux` from `procps-ng`.

A better alternative is using `top`, but we all know that `top` does not close immediately after fetching the CPU usage.. So... yeah.

[2] Since Haiku does NOT use Xorg, it is technically impossible to fetch information about DEs and WMs. (Well, it is possible, just not with Xorg, and I don't know how to fetch it yet)

[3] ~~Fuck Haiku's `df`, it effectively makes `getdisk` impossible, _for now_~~ I need to know how Haiku handles shit when the case is two/more partitions mounted inside a filesystem.

[4] ~~No laptop to fetch `getbattery` and test it on. But~~ some Haiku users said that it is possible to get battery information, I just don't know how, from the terminal. I'll check it with my laptop with a Live USB later on.

This may or may not be merged into my own `master`. Feel free to test it, though.
