### PR TITLE
Added initial detection for GNU (Hurd) systems

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -30,6 +30,7 @@ getos() {
         *"BSD" | "DragonFly" | "Bitrig") os="BSD" ;;
         "CYGWIN"*) os="Windows" ;;
         "SunOS") os="Solaris" ;;
+        "GNU"*) os="GNU" ;;
         *) printf "%s\n" "Unknown OS detected: $(uname)"; exit 1 ;;
     esac
 }
@@ -122,7 +123,7 @@ getdistro() {
     [ "$distro" ] && return
 
     case "$os" in
-        "Linux" )
+        "Linux" | "GNU")
             if grep -q 'Microsoft' /proc/version >/dev/null 2>&1 || \
                grep -q 'Microsoft' /proc/sys/kernel/osrelease >/dev/null 2>&1; then
                 case "$distro_shorthand" in
@@ -305,7 +306,7 @@ getkernel() {
 getuptime() {
     # Get uptime in seconds
     case "$os" in
-        "Linux" | "Windows")
+        "Linux" | "Windows" | "GNU")
             seconds="$(< /proc/uptime)"
             seconds="${seconds/.*}"
         ;;
@@ -376,7 +377,7 @@ getuptime() {
 
 getpackages() {
     case "$os" in
-        "Linux" | "iPhone OS" | "Solaris")
+        "Linux" | "iPhone OS" | "Solaris" | "GNU")
             type -p pacman >/dev/null 2>&1 && \
                 packages="$(pacman -Qq --color never | wc -l)"
 
@@ -899,7 +900,7 @@ getcpu_usage() {
             cpu_usage="${cpu_usage//[[:space:]]}"
         ;;
 
-        "Linux" | "Mac OS X" | "iPhone OS" | "BSD" | "Solaris")
+        "Linux" | "Mac OS X" | "iPhone OS" | "BSD" | "Solaris" | "GNU")
             # Get cores if unset
             if [ -z "$cores" ]; then
                 case "$os" in
@@ -929,7 +930,7 @@ getcpu_usage() {
 
 getgpu() {
     case "$os" in
-        "Linux")
+        "Linux" | "GNU")
             # Use cache if it exists
             if [ -f "/tmp/neofetch/gpu" ]; then
                 source "/tmp/neofetch/gpu"
@@ -1040,7 +1041,7 @@ getgpu() {
 
 getmemory() {
     case "$os" in
-        "Linux" | "Windows")
+        "Linux" | "Windows" | "GNU")
             # MemUsed = Memtotal + Shmem - MemFree - Buffers - Cached - SReclaimable
             # Source: https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
             while IFS=":" read -r a b; do
@@ -1220,7 +1221,7 @@ getsong() {
 
 getresolution() {
     case "$os" in
-        "Linux" | "BSD" | "Solaris")
+        "Linux" | "BSD" | "Solaris" | "GNU")
             if type -p xrandr >/dev/null 2>&1; then
                 case "$refresh_rate" in
                     "on") resolution="$(xrandr --nograb --current | awk 'match($0,/[0-9]*\.[0-9]*\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')" ;;
@@ -1552,7 +1553,7 @@ gettermfont() {
 getdisk() {
     # df flags
     case "$os" in
-        "Linux" | "iPhone OS" | "Windows" | "Solaris")
+        "Linux" | "iPhone OS" | "Windows" | "Solaris" | "GNU")
             df_flags="-h -l --total"
             df_dir="total"
 
@@ -1747,7 +1748,7 @@ getusers() {
 
 getbirthday() {
     case "$os" in
-        "linux" | "iPhone OS")
+        "Linux" | "GNU" | "iPhone OS")
             birthday="$(ls -alct --full-time / | awk '/lost\+found|private/ {printf  $6 " " $7}')"
             date_cmd="$(date -d"$birthday" "$birthday_format")"
         ;;


### PR DESCRIPTION
## Description
### Features

Adds detection for GNU Hurd systems.
### Issues
- There are currently no way to detect CPU name because `/proc/cpuinfo` does not exist, although Hurd's `/proc` are surprisingly similar to Linux.
- There are currently no way to detect battery, because no `/sys`.
- Neither `ip` nor `ifconfig` exists in a Hurd system, but in shutdown screen they do know the local IP. So maybe they use dhcpd somehow.
### TODO
- [ ] Add localip support

NOTE: All tests are done in a fresh Debian GNU/Hurd system in a VM.
